### PR TITLE
Fix not shown properties for "custom" datatype option

### DIFF
--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.controller.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.controller.js
@@ -168,7 +168,7 @@
 
         // Init availableDataTypes
         $scope.availableDataTypes = angular.copy($scope.dialogData.availableDataTypes);
-        $scope.availableDataTypes.push({
+        $scope.availableDataTypes.unshift({
             guid: guidEmpty,
             name: "- - custom - -"
         });

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.controller.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.controller.js
@@ -1,6 +1,8 @@
 ﻿angular.module("umbraco").controller("LeBlender.Dialog.ParameterConfig.Prevalues.Controller",
     function ($scope, assetsService, $http, LeBlenderRequestHelper, dialogService) {
 
+        var guidEmpty = "00000000-0000-0000-0000-000000000000";
+
         /***************************************/
         /* legacy adaptor 0.9.15 */
         /***************************************/
@@ -8,25 +10,32 @@
         if ($scope.dialogData.parameter && $scope.dialogData.parameter.propretyType) {
 
             switch ($scope.dialogData.parameter.propretyType.name) {
-                case "Textstring": $scope.dialogData.parameter.dataType = "0cc0eba1-9960-42c9-bf9b-60e150b429ae";
+                case "Textstring":
+                    $scope.dialogData.parameter.dataType = "0cc0eba1-9960-42c9-bf9b-60e150b429ae";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Textarea": $scope.model.value.dataType = "c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3";
+                case "Textarea":
+                    $scope.model.value.dataType = "c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Rich Text Editor": $scope.dialogData.parameter.dataType = "ca90c950-0aff-4e72-b976-a30b1ac57dad";
+                case "Rich Text Editor":
+                    $scope.dialogData.parameter.dataType = "ca90c950-0aff-4e72-b976-a30b1ac57dad";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Boolean": $scope.dialogData.parameter.dataType = "92897bc6-a5f3-4ffe-ae27-f2e7e33dda49";
+                case "Boolean":
+                    $scope.dialogData.parameter.dataType = "92897bc6-a5f3-4ffe-ae27-f2e7e33dda49";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Media Picker": $scope.dialogData.parameter.dataType = "93929b9a-93a2-4e2a-b239-d99334440a59";
+                case "Media Picker":
+                    $scope.dialogData.parameter.dataType = "93929b9a-93a2-4e2a-b239-d99334440a59";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Multi Media Picker": $scope.dialogData.parameter.dataType = "7e3962cc-ce20-4ffc-b661-5897a894ba7e";
+                case "Multi Media Picker":
+                    $scope.dialogData.parameter.dataType = "7e3962cc-ce20-4ffc-b661-5897a894ba7e";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
-                case "Content Picker": $scope.dialogData.parameter.dataType = "a6857c73-d6e9-480c-b6e6-f15f6ad11125";
+                case "Content Picker":
+                    $scope.dialogData.parameter.dataType = "a6857c73-d6e9-480c-b6e6-f15f6ad11125";
                     $scope.dialogData.parameter.propretyType = {};
                     break;
                 case "Multi Content Picker":
@@ -53,7 +62,7 @@
 
         // Control if the property is custom 
         $scope.isCustom = function () {
-            if ($scope.model.value.dataType === "") {
+            if ($scope.model.value.dataType === guidEmpty) {
                 return true;
             }
             else {
@@ -66,6 +75,12 @@
 
             if (!$scope.model.value.propretyType) {
                 $scope.model.value.propretyType = {};
+            }
+
+            if (!$scope.model.value.dataType) {
+                // find "Textstring" datatype from guid and select on init - fallback to first element
+                var datatypeToSelect = _.findWhere($scope.availableDataTypes, { guid: '0cc0eba1-9960-42c9-bf9b-60e150b429ae' }) || $scope.availableDataTypes[0];
+                $scope.model.value.dataType = datatypeToSelect.guid;
             }
 
             if (!$scope.model.value.dataType && $scope.model.value.propretyType) {
@@ -154,9 +169,9 @@
         // Init availableDataTypes
         $scope.availableDataTypes = angular.copy($scope.dialogData.availableDataTypes);
         $scope.availableDataTypes.push({
-            guid: "",
+            guid: guidEmpty,
             name: "- - custom - -"
-        })
+        });
 
         // Extend model
         angular.extend($scope, {
@@ -168,7 +183,7 @@
         if (!$scope.model.value) {
             $scope.model.value = {
                 name: "",
-                alias: "",
+                alias: ""
             };
         }
 

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.html
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.prevalues.html
@@ -25,7 +25,7 @@
                         </umb-control-group>
 
                         <umb-control-group label="Description" description="">
-                            <textarea class="umb-editor umb-textstring" type="text" ng-model="model.value.description" />
+                            <textarea class="umb-editor umb-textstring" style="height: 100px;" ng-model="model.value.description" />
                         </umb-control-group>
 
                         <div ng-show="isCustom()">
@@ -36,7 +36,7 @@
 
                         <div ng-show="isCustom()">
                             <umb-control-group label="Config" description="">
-                                <textarea class="umb-editor umb-textstring" type="text" style="min-width: 66.6%; height: 100px;" ng-model="textAreaconfig" />
+                                <textarea class="umb-editor umb-textstring" style="height: 100px;" ng-model="textAreaconfig" />
                             </umb-control-group>
                         </div>
 

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/package.manifest
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/package.manifest
@@ -3,7 +3,7 @@
         {
             "name": "Rich text editor",
             "alias": "rte",
-			"isGridEditor": true, 
+			      "isGridEditor": true, 
             "editor": {
                 "view": "rte"
             }
@@ -11,7 +11,7 @@
         {
             "name": "Image",
             "alias": "image",
-			"isGridEditor": true, 
+			      "isGridEditor": true, 
             "editor": {
                 "view": "media"
             }
@@ -19,7 +19,7 @@
         {
             "name": "Macro",
             "alias": "macro",
-			"isGridEditor": true, 
+			      "isGridEditor": true, 
             "editor": {
                 "view": "macro"
             }
@@ -27,7 +27,7 @@
         {
             "name": "Embed",
             "alias": "embed",
-			"isGridEditor": true, 
+			      "isGridEditor": true, 
             "editor": {
                 "view": "embed"
             }
@@ -35,7 +35,7 @@
         {
             "name": "Textstring",
             "alias": "textstring",
-			"isGridEditor": true, 
+			      "isGridEditor": true, 
             "editor": {
                 "view": "textstring"
             },
@@ -61,7 +61,7 @@
         {
             "name": "LeBlender Editor",
             "alias": "leblenderEditor",
-			"isGridEditor": true,
+			      "isGridEditor": true,
             "editor": {
                 "view": "/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html"
             },


### PR DESCRIPTION
Issue: https://github.com/Lecoati/LeBlender/issues/72

Now it show the two additional properties.
It also save an empty guid with value `00000000-0000-0000-0000-000000000000` instead of just an empty string as guid value.

![image](https://user-images.githubusercontent.com/2919859/29641995-97a13366-8866-11e7-8630-46d7b9753a0b.png)

Furthermore on init it select `Textstring` datatype on init - we use LeBlender in almost every Umbraco project and I think textstring datatype is the most common one that is used.
In datatype options in property setting dialog I have moved "custom" option to first option in list like for grid editor dropdown and might be easier to find/see.