### PR TITLE
Two fixes for issue #35 and problems with plugin-controllers

### DIFF
--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/views/Base.cshtml
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/views/Base.cshtml
@@ -1,11 +1,10 @@
 ﻿@using System.Web.Mvc.Html;
 @using Lecoati.LeBlender.Extension
 @using Lecoati.LeBlender.Extension.Models
-@using System.Web.Mvc;
 
 @try
 {
-    
+
     string guid = Model.guid != null && Model.guid.Value != null ? Model.guid.Value.ToString() : "";
     LeBlenderModel blenderModel = Helper.DeserializeBlenderModel(Model);
 
@@ -13,6 +12,15 @@
         "" : Model.editor.config.frontView.Value;
 
     ViewDataDictionary datas = new ViewDataDictionary() { { "editorAlias", Model.editor.alias }, { "frontView", frontView } };
+    // Remove all Keys you entered in datas.
+    var keys = ViewData.Keys.Where( k =>
+         !datas.Keys.Any( x => x == k )
+    );
+	// Add the keys from ViewData to the new Dictionary
+    foreach (var key in keys)
+    {
+        datas.Add( key, ViewData["key"] );
+    }
 
     int cacheExpiration = Helper.GetCacheExpiration(Model.editor.alias.ToString());
 

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/views/LeBlender.cshtml
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/views/LeBlender.cshtml
@@ -1,3 +1,3 @@
 ﻿@using System.Web.Mvc.Html;
    
-@(Html.Action("RenderEditor", "LeBlender", new { editorAlias = ViewData["editorAlias"], frontView = ViewData["frontView"], model = Model }))
+@(Html.Action("RenderEditor", "LeBlender", new { area="", editorAlias = ViewData["editorAlias"], frontView = ViewData["frontView"], model = Model }))


### PR DESCRIPTION
- Pull Request for https://github.com/Lecoati/LeBlender/issues/35. The original fix causes a data loss, if somebody entered data in the ViewData dict.
- Added an area specifier to make sure, that the grid editor views are found under ~/Views. The views won't be found, if a view shows a form which is posted to a plugin-controller. After the post all views are searched in the area instead of the ~/Views directory.