### PR TITLE
Fix dialog bug

### DIFF
--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/leblendereditor.controller.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/leblendereditor.controller.js
@@ -92,14 +92,8 @@
               s4() + '-' + s4() + s4() + s4();
         }
 
-        if ((!$scope.control.value || $scope.control.value.length == 0) &&
-            ($scope.control.editor.config && $scope.control.editor.config.editors && $scope.control.editor.config.editors.length > 0)) {
-            $scope.openListParameter();
-        }
-        else {
-            if (!$scope.control.guid)
-                $scope.control.guid = guid()
-        }
+        if (!$scope.control.guid)
+            $scope.control.guid = guid()
 
         $scope.setPreview = function () {
             if ($scope.control.editor.config


### PR DESCRIPTION
It fixes the bug of that open a editor dialog for each leblender editor inside Document Type or for each empty leblender editor on Edit content page. 

See the link: https://our.umbraco.org/projects/backoffice-extensions/leblender/bug-reports/71826-leblender-dialog-opens-automatically-when-theres-only-one-editor-in-the-grid-730