### PR TITLE
add http item leblender.contentId

### DIFF
--- a/Src/Lecoati.LeBlender.Extension/LeBlenderHelper.cs
+++ b/Src/Lecoati.LeBlender.Extension/LeBlenderHelper.cs
@@ -222,7 +222,7 @@ namespace Lecoati.LeBlender.Extension
             }
             else
             {
-                int contenId = int.Parse(HttpContext.Current.Request["id"]);
+	            int contenId = int.Parse((string) (HttpContext.Current.Items["leblender.contentId"]??HttpContext.Current.Request["id"]));
                 return (PublishedContentType)ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem(
                     "LeBlender_GetTargetContentType_" + contenId,
                     () =>


### PR DESCRIPTION
I had a problem with following call
`//try to find one 
				JObject jObj = JObject.Parse(Umbraco.TypedContent(component.PageId).GetPropertyValue<string>(component.PropertyAlias));
				HttpContext.Items.Add("leblender-content-id", component.ComponetId);
				var foundGuid = jObj.Descendants().OfType<JProperty>().FirstOrDefault(p => p.Name == "guid" && p.Value.ToString() == component.ComponetId.ToString());
				if (foundGuid != null && foundGuid.Parent != null)
					TempData.AddFormConfiguration(component.ComponetId, foundGuid.Parent.ToObject<LeBlenderModel>().Items.FirstOrDefault()?.GetAs<FormularConfiguration>());//set new data`

It throws int.Parse exception...
I am inside SurfaceController action method which was called by ajax,